### PR TITLE
Update init script

### DIFF
--- a/atlantis-server
+++ b/atlantis-server
@@ -18,9 +18,19 @@ if [ "${ATLANTIS_ENABLED}" == "true" ]; then
     echo "WARN: CHAMBER_KMS_KEY_ALIAS is not set"
   fi
 
+  if [ -n "${TF_LOG}" ]; then
+    echo "WARN: TF_LOG is set which may expose secrets"
+  fi
+
   # create atlantis user & group
   (getent group ${ATLANTIS_GROUP} || addgroup ${ATLANTIS_GROUP}) >/dev/null
   (getent passwd ${ATLANTIS_USER} || adduser -S -G ${ATLANTIS_GROUP} ${ATLANTIS_USER}) >/dev/null
+
+  # Allow atlantis to use /dev/shm
+  if [ -d /dev/shm ]; then
+    chown "${ATLANTIS_USER}:${ATLANTIS_GROUP}" /dev/shm
+    chmod 700 /dev/shm
+  fi
 
   if [ -n "${ATLANTIS_ALLOW_PRIVILEGED_PORTS}" ]; then
     setcap "cap_net_bind_service=+ep" $(which atlantis)


### PR DESCRIPTION
## what
* Change ownership of `/dev/shm` to atlantis user
* Warn if `TF_LOG` is set

## why
* We run in a single-user container. It's safer to grant `/dev/shm` access to the `atlantis` user so it can write temporary secrets (e.g. SSH keys) to ephemeral memory
* `TF_LOG` may expose secrets